### PR TITLE
 Changed MphUtils.getAllGroups() to return a map of ID and MphGroup. …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **Changes in version 1.10**
 
  - Updated Commons Lang library from version 3.4 to version 3.6.
+ - Changed MphUtils.getAllGroups() to return a map of ID and MphGroup.
+ - MphGroup names changed from "Year Name" to "Name (Year)".
 
 **Changes in version 1.9**
 

--- a/src/main/java/com/imsweb/mph/MphConstants.java
+++ b/src/main/java/com/imsweb/mph/MphConstants.java
@@ -31,21 +31,21 @@ public class MphConstants {
     public static final String MP_2007_URINARY_GROUP_ID = "mp_2007_urinary";
 
     //Group Names for the set of rules
-    public static final String MP_1998_HEMATO_GROUP_NAME = "1998 Hematopoietic";
-    public static final String MP_2001_HEMATO_GROUP_NAME = "2001 Hematopoietic";
-    public static final String MP_2010_HEMATO_GROUP_NAME = "2010 Hematopoietic";
-    public static final String MP_2004_SOLID_MALIGNANT_GROUP_NAME = "2004 Solid Malignant";
-    public static final String MP_2004_BENIGN_BRAIN_GROUP_NAME = "2004 Benign Brain";
-    public static final String MP_2007_BENIGN_BRAIN_GROUP_NAME = "2007 Benign Brain";
-    public static final String MP_2007_BREAST_GROUP_NAME = "2007 Breast";
-    public static final String MP_2007_COLON_GROUP_NAME = "2007 Colon";
-    public static final String MP_2007_HEAD_AND_NECK_GROUP_NAME = "2007 Head and Neck";
-    public static final String MP_2007_KIDNEY_GROUP_NAME = "2007 Kidney";
-    public static final String MP_2007_LUNG_GROUP_NAME = "2007 Lung";
-    public static final String MP_2007_MALIGNANT_BRAIN_GROUP_NAME = "2007 Malignant Brain";
-    public static final String MP_2007_MELANOMA_GROUP_NAME = "2007 Melanoma";
-    public static final String MP_2007_OTHER_SITES_GROUP_NAME = "2007 Other Sites";
-    public static final String MP_2007_URINARY_GROUP_NAME = "2007 Urinary";
+    public static final String MP_1998_HEMATO_GROUP_NAME = "Hematopoietic (1998)";
+    public static final String MP_2001_HEMATO_GROUP_NAME = "Hematopoietic (2001)";
+    public static final String MP_2010_HEMATO_GROUP_NAME = "Hematopoietic (2010)";
+    public static final String MP_2004_SOLID_MALIGNANT_GROUP_NAME = "Solid Malignant (2004)";
+    public static final String MP_2004_BENIGN_BRAIN_GROUP_NAME = "Benign Brain (2004)";
+    public static final String MP_2007_BENIGN_BRAIN_GROUP_NAME = "Benign Brain (2007)";
+    public static final String MP_2007_BREAST_GROUP_NAME = "Breast (2007)";
+    public static final String MP_2007_COLON_GROUP_NAME = "Colon (2007)";
+    public static final String MP_2007_HEAD_AND_NECK_GROUP_NAME = "Head and Neck (2007)";
+    public static final String MP_2007_KIDNEY_GROUP_NAME = "Kidney (2007)";
+    public static final String MP_2007_LUNG_GROUP_NAME = "Lung (2007)";
+    public static final String MP_2007_MALIGNANT_BRAIN_GROUP_NAME = "Malignant Brain (2007)";
+    public static final String MP_2007_MELANOMA_GROUP_NAME = "Melanoma (2007)";
+    public static final String MP_2007_OTHER_SITES_GROUP_NAME = "Other Sites (2007)";
+    public static final String MP_2007_URINARY_GROUP_NAME = "Urinary (2007)";
 
     //Topographies
     public static final String COLON = "C18";
@@ -60,7 +60,7 @@ public class MphConstants {
     public static final String URETHRA = "C680";
     public static final String THYROID = "C739";
     public static final String LYMPH_NODE = "C77";
-   
+
     public static final List<String> EXACT_MATCH_SITES = Collections.unmodifiableList(Arrays.asList("C18", "C21", "C38", "C40", "C41", "C44", "C47", "C49"));
     public static final List<String> TONGUE = Collections.unmodifiableList(Arrays.asList("C01", "C02"));
     public static final List<String> MOUTH = Collections.unmodifiableList(Arrays.asList("C05", "C06"));
@@ -70,15 +70,15 @@ public class MphConstants {
     public static final List<String> BILIARY = Collections.unmodifiableList(Arrays.asList("C23", "C24"));
     public static final List<String> SINUS = Collections.unmodifiableList(Arrays.asList("C30", "C31"));
     public static final List<String> LUNG = Collections.unmodifiableList(Arrays.asList("C33", "C34"));
-    
+
     public static final String MEDIASTINUM = "C370-C383,C388";
     public static final String FEMALE_GENITAL = "C510-C529,C577-C579";
     public static final String OVARY_OR_FEMALE_GENITAL = "C569-C574";
-    
+
     public static final List<String> MALE_GENITAL = Collections.unmodifiableList(Arrays.asList("C60", "C63"));
     public static final List<String> KIDNEY_OR_URINARY = Collections.unmodifiableList(Arrays.asList("C64", "C65", "C66", "C68"));
     public static final List<String> ENDOCRINE = Collections.unmodifiableList(Arrays.asList("C74", "C75"));
-    public static final List<String> UPPER_LIP =Collections.unmodifiableList( Arrays.asList("C000", "C003"));
+    public static final List<String> UPPER_LIP = Collections.unmodifiableList(Arrays.asList("C000", "C003"));
     public static final List<String> LOWER_LIP = Collections.unmodifiableList(Arrays.asList("C001", "C004"));
     public static final List<String> UPPER_GUM = Collections.unmodifiableList(Collections.singletonList("C030"));
     public static final List<String> LOWER_GUM = Collections.unmodifiableList(Collections.singletonList("C031"));

--- a/src/main/java/com/imsweb/mph/MphUtils.java
+++ b/src/main/java/com/imsweb/mph/MphUtils.java
@@ -5,7 +5,9 @@ package com.imsweb.mph;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.math.NumberUtils;
 
@@ -65,7 +67,7 @@ public final class MphUtils {
     private HematoDbUtilsProvider _provider = null;
 
     // the cached groups of rules used by the instance
-    private List<MphGroup> _groups = new ArrayList<>();
+    private Map<String, MphGroup> _groups = new HashMap<>();
 
     /**
      * Initialized the instance with the given provider; this allows to use a customized provider instead of the default one.
@@ -93,6 +95,13 @@ public final class MphUtils {
     }
 
     /**
+     * Adds an ID and a MphGroup to the _groups Map.
+     */
+    private void addGroup(MphGroup newGroup) {
+        _groups.put(newGroup.getId(), newGroup);
+    }
+
+    /**
      * Private constructor, use the getInstance() method.
      * @param provider the provider to use for this instance, cannot be null
      */
@@ -102,29 +111,29 @@ public final class MphUtils {
         _provider = provider;
 
         // 1998 Hematopoietic rules
-        _groups.add(new Mp1998HematopoieticGroup());
+        addGroup(new Mp1998HematopoieticGroup());
 
         // 2001 Hematopoietic rules
-        _groups.add(new Mp2001HematopoieticGroup());
+        addGroup(new Mp2001HematopoieticGroup());
 
         // 2010 Hematopoietic rules
-        _groups.add(new Mp2010HematopoieticGroup());
+        addGroup(new Mp2010HematopoieticGroup());
 
         // 2004 solid tumor rules 
-        _groups.add(new Mp2004BenignBrainGroup());
-        _groups.add(new Mp2004SolidMalignantGroup());
+        addGroup(new Mp2004BenignBrainGroup());
+        addGroup(new Mp2004SolidMalignantGroup());
 
         // 2007 solid tumor rules
-        _groups.add(new Mp2007HeadAndNeckGroup());
-        _groups.add(new Mp2007ColonGroup());
-        _groups.add(new Mp2007LungGroup());
-        _groups.add(new Mp2007MelanomaGroup());
-        _groups.add(new Mp2007BreastGroup());
-        _groups.add(new Mp2007KidneyGroup());
-        _groups.add(new Mp2007UrinaryGroup());
-        _groups.add(new Mp2007BenignBrainGroup());
-        _groups.add(new Mp2007MalignantBrainGroup());
-        _groups.add(new Mp2007OtherSitesGroup());
+        addGroup(new Mp2007HeadAndNeckGroup());
+        addGroup(new Mp2007ColonGroup());
+        addGroup(new Mp2007LungGroup());
+        addGroup(new Mp2007MelanomaGroup());
+        addGroup(new Mp2007BreastGroup());
+        addGroup(new Mp2007KidneyGroup());
+        addGroup(new Mp2007UrinaryGroup());
+        addGroup(new Mp2007BenignBrainGroup());
+        addGroup(new Mp2007MalignantBrainGroup());
+        addGroup(new Mp2007OtherSitesGroup());
     }
 
     /**
@@ -287,17 +296,18 @@ public final class MphUtils {
         if (!GroupUtility.validateProperties(primarySite, histology, behavior, year))
             return null;
 
-        for (MphGroup group : getAllGroups())
-            if (group.isApplicable(primarySite, histology, behavior, year))
-                return group;
+        //for (MphGroup group : getAllGroups())
+        for (Map.Entry<String, MphGroup> entry : getAllGroups().entrySet())
+            if (entry.getValue().isApplicable(primarySite, histology, behavior, year))
+                return entry.getValue();
 
         return null;
     }
 
     /**
-     * Returns the list of all group of rules used by this instance.
+     * Returns a map of all groups of rules used by this instance.
      */
-    public List<MphGroup> getAllGroups() {
-        return Collections.unmodifiableList(_groups);
+    public Map<String, MphGroup> getAllGroups() {
+        return Collections.unmodifiableMap(_groups);
     }
 }

--- a/src/test/java/com/imsweb/mph/MphUtilsTest.java
+++ b/src/test/java/com/imsweb/mph/MphUtilsTest.java
@@ -4,6 +4,7 @@
 package com.imsweb.mph;
 
 import java.time.LocalDate;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -113,6 +114,27 @@ public class MphUtilsTest {
         Assert.assertEquals(new Mp2004SolidMalignantGroup(), _utils.findCancerGroup("C718", "8700", "3", 2006));
         Assert.assertEquals(new Mp2004SolidMalignantGroup(), _utils.findCancerGroup("C752", "9000", "3", 1980));
         Assert.assertEquals(new Mp2004SolidMalignantGroup(), _utils.findCancerGroup("C009", "9000", "3", 2000));
+    }
+
+    @Test
+    public void testGetAllGroups() {
+        Map<String, MphGroup> testMap = _utils.getAllGroups();
+
+        Assert.assertEquals(MphConstants.MP_1998_HEMATO_GROUP_ID, testMap.get(MphConstants.MP_1998_HEMATO_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2001_HEMATO_GROUP_ID, testMap.get(MphConstants.MP_2001_HEMATO_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2010_HEMATO_GROUP_ID, testMap.get(MphConstants.MP_2010_HEMATO_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2004_SOLID_MALIGNANT_GROUP_ID, testMap.get(MphConstants.MP_2004_SOLID_MALIGNANT_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2004_BENIGN_BRAIN_GROUP_ID, testMap.get(MphConstants.MP_2004_BENIGN_BRAIN_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2007_BENIGN_BRAIN_GROUP_ID, testMap.get(MphConstants.MP_2007_BENIGN_BRAIN_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2007_BREAST_GROUP_ID, testMap.get(MphConstants.MP_2007_BREAST_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2007_COLON_GROUP_ID, testMap.get(MphConstants.MP_2007_COLON_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2007_HEAD_AND_NECK_GROUP_ID, testMap.get(MphConstants.MP_2007_HEAD_AND_NECK_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2007_KIDNEY_GROUP_ID, testMap.get(MphConstants.MP_2007_KIDNEY_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2007_LUNG_GROUP_ID, testMap.get(MphConstants.MP_2007_LUNG_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2007_MALIGNANT_BRAIN_GROUP_ID, testMap.get(MphConstants.MP_2007_MALIGNANT_BRAIN_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2007_MELANOMA_GROUP_ID, testMap.get(MphConstants.MP_2007_MELANOMA_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2007_OTHER_SITES_GROUP_ID, testMap.get(MphConstants.MP_2007_OTHER_SITES_GROUP_ID).getId());
+        Assert.assertEquals(MphConstants.MP_2007_URINARY_GROUP_ID, testMap.get(MphConstants.MP_2007_URINARY_GROUP_ID).getId());
     }
 
     @Test


### PR DESCRIPTION
…Added unit tests. MphGroup names changed from "Year Name" to "Name (Year)". (#23)

Side question: 
In the file MphConstants.java, the Map MALIGNANT_BRAIN_2007_CHART1 has duplicate key values of:
`        content.put("9392", "Embryonal tumors"); //Ependymoblastoma `
`        content.put("9392", "Ependymal tumors"); //Anasplastic ependymoma `
Does this need to be fixed?